### PR TITLE
fix: 방 이동 시 안읽음 카운트 순간 노출 문제 수정

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
@@ -36,9 +36,9 @@ public class ChatRoomSequenceService {
     @CircuitBreaker(name = "redis", fallbackMethod = "genMessageSeqFallback")
     public Long genMessageSeq(Long roomId, Long userId) {
         log.info("genMessageSeq 진입 - circuitBreaker state={}",
-                registry.circuitBreaker("redis").getState()); // 추가
+                registry.circuitBreaker("redis").getState());
         if (!policySelector.select().canSend(userId)) {
-            log.info("레이트 리밋 초과 - 예외 던짐 userId={}", userId); // 추가
+            log.info("레이트 리밋 초과 - 예외 던짐 userId={}", userId);
             throw new ChatMessageException(ChatMessageErrorCode.TOO_MANY_REQUESTS);
         }
         return chatRoomRedisService.genMessageSeq(roomId);

--- a/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
@@ -51,6 +51,7 @@ public class GitMessageService {
 			case "issues" -> GitMessageDto.fromIssue(payload);
 			case "pull_request" -> GitMessageDto.fromPullRequest(payload);
 			case "pull_request_review" -> GitMessageDto.fromPullRequestReview(payload);
+			case "workflow_run" -> GitMessageDto.fromWorkflowRun(payload);
 			default -> null;
 		};
 

--- a/backend/src/main/java/project/backend/domain/chat/github/dto/GitEventType.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/dto/GitEventType.java
@@ -1,5 +1,5 @@
 package project.backend.domain.chat.github.dto;
 
 public enum GitEventType {
-    ISSUE_OPEN, PR_OPEN, PR_MERGED, PR_REVIEW
+    ISSUE_OPEN, PR_OPEN, PR_MERGED, PR_REVIEW, WORKFLOW_RUN
 }

--- a/backend/src/main/java/project/backend/domain/chat/github/dto/GitMessageDto.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/dto/GitMessageDto.java
@@ -88,6 +88,35 @@ public class GitMessageDto {
 			content);
 	}
 
+	public static GitMessageDto fromWorkflowRun(Map<String, Object> payload) {
+		Map<String, Object> workflowRun = (Map<String, Object>) payload.get("workflow_run");
+		if (workflowRun == null) return null;
+
+		String action = (String) payload.get("action");
+		if (!"completed".equals(action)) return null;
+
+		String name = (String) workflowRun.get("name");
+		String conclusion = (String) workflowRun.get("conclusion");
+		String url = (String) workflowRun.get("html_url");
+		String branch = (String) workflowRun.get("head_branch");
+		Map<String, Object> actor = (Map<String, Object>) workflowRun.get("triggering_actor");
+		String triggerBy = actor != null ? (String) actor.get("login") : "unknown";
+
+		String emoji = switch (conclusion) {
+			case "success" -> "✅";
+			case "failure" -> "❌";
+			case "cancelled" -> "⚠️";
+			default -> "❓";
+		};
+
+		String content = emoji + " [" + name + "] " + conclusion.toUpperCase()
+				+ " by " + triggerBy
+				+ " (branch: " + branch + ")"
+				+ "\n" + url;
+
+		return GitMessageDto.of(GitEventType.WORKFLOW_RUN, triggerBy, content);
+	}
+
 	public static GitMessageDto of(GitEventType type, String actor,
 		String content) {
 		return GitMessageDto.builder()

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -30,7 +30,7 @@ const Sidebar = ({ onStartChat }) => {
   const [roomId, setRoomId] = useState(null)
 
   const { currentUser } = useUser()
-  const { getAlarmStatus, alarmStatusMap, alarmRooms, updateRooms, clearUnread } = useAlarm()
+  const { getAlarmStatus, alarmStatusMap, alarmRooms, updateRooms, clearUnread, enterRoom } = useAlarm()
 
   useEffect(() => {
     if (!inviteCode) {
@@ -73,6 +73,8 @@ const Sidebar = ({ onStartChat }) => {
 
   const navigateToRoom = (id, inviteCode) => {
     if (id) {
+      console.log('navigateToRoom enterRoom 호출 id=', id)
+      enterRoom(id)
       clearUnread(id)
       navigate(`/chat/${inviteCode}`)
     }

--- a/frontend/src/context/AlarmContext.jsx
+++ b/frontend/src/context/AlarmContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback } from "react"
+import { createContext, useContext, useState, useRef, useCallback } from "react"
 
 const AlarmContext = createContext()
 
@@ -7,6 +7,8 @@ export const useAlarm = () => useContext(AlarmContext)
 export const AlarmProvider = ({ children }) => {
   const [alarmStatusMap, setAlarmStatusMap] = useState({})
   const [currentRoomId, setCurrentRoomId] = useState(null)
+  const currentRoomIdRef = useRef(null)
+
   const [alarmRooms, setAlarmRooms] = useState(() => {
     try {
       const cached = localStorage.getItem('sidebar_rooms_cache')
@@ -28,7 +30,6 @@ export const AlarmProvider = ({ children }) => {
     setAlarmRooms(prev => {
       return rooms.map(r => {
         const existing = prev.find(p => Number(p.uniqueId) === Number(r.uniqueId))
-        // 서버 unreadCount가 있으면 서버값 사용, 없으면 기존값 유지
         return {
           ...r,
           unreadCount: r.unreadCount ?? existing?.unreadCount ?? 0
@@ -39,6 +40,7 @@ export const AlarmProvider = ({ children }) => {
   }, [])
 
   const incrementUnread = useCallback((roomUniqueId) => {
+    console.trace('incrementUnread 호출 roomId=', roomUniqueId)
     setAlarmRooms(prev => prev.map(r =>
       Number(r.uniqueId) === Number(roomUniqueId)
         ? { ...r, unreadCount: (r.unreadCount ?? 0) + 1 }
@@ -63,10 +65,12 @@ export const AlarmProvider = ({ children }) => {
   }, [])
 
   const enterRoom = useCallback((roomId) => {
+    currentRoomIdRef.current = roomId  // 즉시 동기 업데이트
     setCurrentRoomId(roomId)
   }, [])
 
   const leaveRoom = useCallback(() => {
+    currentRoomIdRef.current = null  // 즉시 동기 업데이트
     setCurrentRoomId(null)
   }, [])
 
@@ -75,6 +79,7 @@ export const AlarmProvider = ({ children }) => {
       alarmStatusMap,
       alarmRooms,
       currentRoomId,
+      currentRoomIdRef,
       updateAlarm,
       getAlarmStatus,
       updateRooms,

--- a/frontend/src/context/ChatSubscriptionProvider.jsx
+++ b/frontend/src/context/ChatSubscriptionProvider.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useCallback } from "react"
+import { createContext, useContext, useEffect, useCallback } from "react"
 import { useWebSocketContext } from "../components/common/WebSocketContext"
 import { useAlarm } from "./AlarmContext"
 
@@ -7,10 +7,7 @@ export const useChatSubscription = () => useContext(ChatSubscriptionContext)
 
 export const ChatSubscriptionProvider = ({ children }) => {
   const { stompClientRef, connected } = useWebSocketContext()
-  const { alarmRooms, currentRoomId, incrementUnread, bringRoomToTop, getAlarmStatus } = useAlarm()
-
-  const currentRoomIdRef = useRef(currentRoomId)
-  useEffect(() => { currentRoomIdRef.current = currentRoomId }, [currentRoomId])
+  const { alarmRooms, currentRoomIdRef, incrementUnread, bringRoomToTop, getAlarmStatus } = useAlarm()
 
   const chatRoomIdsKey = alarmRooms.map(r => r.uniqueId).join(',')
 
@@ -30,8 +27,11 @@ export const ChatSubscriptionProvider = ({ children }) => {
         try {
           const received = JSON.parse(message.body)
           if (received.type === "EVENT") return
-          if (Number(currentRoomIdRef.current) === Number(room.uniqueId)) return
-
+          if (Number(currentRoomIdRef.current) === Number(room.uniqueId)) {
+            console.log('현재 방 무시 roomId=', room.uniqueId)
+            return
+          }
+          console.log('incrementUnread 호출 roomId=', room.uniqueId, 'currentRoomIdRef=', currentRoomIdRef.current)
           incrementUnread(room.uniqueId)
           bringRoomToTop(room.uniqueId)
 

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -71,7 +71,7 @@ const VirtuosoMessageItem = React.memo(({
 const ChatRoom = () => {
   const { inviteCode } = useParams();
   const { currentUser } = useUser();
-  const { getAlarmStatus, updateAlarm } = useAlarm();
+  const { getAlarmStatus, updateAlarm, enterRoom, clearUnread } = useAlarm();
 
   const [messages, setMessages] = useState([]);
   const [content, setContent] = useState('');
@@ -152,6 +152,13 @@ const ChatRoom = () => {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (roomId) {
+      enterRoom(roomId)
+      clearUnread(roomId)
+    }
+  }, [roomId, enterRoom, clearUnread])
 
   const handleCodeClick = (message) => {
     setSelectedCodeMessage(message);


### PR DESCRIPTION
## 🛰️ Issue Number
merge to dev #11 

## 🪐 작업 내용
### 방 이동 시 안읽음 카운트 순간 노출 문제 수정

**원인**
- `ChatRoom` 입장 시 `enterRoom()`을 호출하지 않아 `currentRoomIdRef`가 항상 `null` 상태
- `currentRoomIdRef`가 `null`이면 `ChatSubscriptionProvider`가 현재 방 메시지를 무시하지 못해 `incrementUnread` 호출됨
- 방 이동 시 `clearUnread` 타이밍이 늦어 순간적으로 unread count가 노출됨

**변경 사항**
- `AlarmContext`에 `currentRoomIdRef` 추가하여 `enterRoom/leaveRoom` 시 동기적으로 즉시 업데이트
- `ChatRoom` 입장 시 `enterRoom()` + `clearUnread()` 즉시 호출
- `ChatSubscriptionProvider`에서 `currentRoomIdRef`로 현재 방 메시지 필터링

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?