### PR TITLE
fix: 채팅방 목록 조회 시 Redis null sequence DB 복구 및 bulk set 최적화

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRedisRepository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -34,6 +35,10 @@ public class ChatRoomRedisService {
 
     public void setSequence(Long roomId, Long sequence) {
         chatRoomRedisRepository.setSequence(roomId, sequence);
+    }
+
+    public void bulkSetSequences(Map<Long, Long> sequences) {
+        chatRoomRedisRepository.bulkSetSequences(sequences);
     }
 
     public Long getSequence(Long roomId) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
@@ -16,6 +16,7 @@ import project.backend.global.exception.errorcode.ChatRoomErrorCode;
 import project.backend.global.exception.ex.ChatMessageException;
 import project.backend.global.exception.ex.ChatRoomException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -84,7 +85,30 @@ public class ChatRoomSequenceService {
 
     @CircuitBreaker(name = "redis", fallbackMethod = "getSequencesFallback")
     public List<Long> getSequences(List<Long> roomIds) {
-        return chatRoomRedisService.getSequences(roomIds);
+        List<Long> sequences = chatRoomRedisService.getSequences(roomIds);
+
+        List<Long> missingRoomIds = new ArrayList<>();
+        for (int i = 0; i < roomIds.size(); i++) {
+            if (sequences.get(i) == null) {
+                missingRoomIds.add(roomIds.get(i));
+            }
+        }
+
+        if (!missingRoomIds.isEmpty()) {
+            Map<Long, Long> dbSequences = chatRoomRepository.findAllById(missingRoomIds)
+                    .stream()
+                    .collect(Collectors.toMap(ChatRoom::getId, ChatRoom::getLastSequence));
+
+            chatRoomRedisService.bulkSetSequences(dbSequences);
+
+            for (int i = 0; i < roomIds.size(); i++) {
+                if (sequences.get(i) == null) {
+                    sequences.set(i, dbSequences.getOrDefault(roomIds.get(i), 0L));
+                }
+            }
+        }
+
+        return sequences;
     }
 
     public List<Long> getSequencesFallback(List<Long> roomIds, Throwable e) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -1,9 +1,6 @@
 package project.backend.domain.chat.chatroom.dao;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +26,7 @@ public class ChatRoomRedisRepository {
     private final DefaultRedisScript<Long> recoverAndIncrScript;
     private final DefaultRedisScript<List> getAndClearUpdatedRoomsScript;
     private final DefaultRedisScript<Long> setSequenceScript;
+    private final DefaultRedisScript<Void> bulkSetSequenceScript;
 
     public Long genMessageSeq(Long roomId) {
         return redisTemplate.execute(
@@ -94,6 +92,19 @@ public class ChatRoomRedisRepository {
         );
     }
 
+    public void bulkSetSequences(Map<Long, Long> sequences) {
+        if (sequences == null || sequences.isEmpty()) return;
+
+        List<String> keys = new ArrayList<>();
+        List<String> args = new ArrayList<>();
+
+        sequences.forEach((roomId, seq) -> keys.add(String.format(ROOM_SEQUENCE_KEY, roomId)));
+        sequences.forEach((roomId, seq) -> args.add(String.valueOf(seq)));
+        sequences.forEach((roomId, seq) -> args.add(String.valueOf(SEQUENCE_TTL_SEC)));
+
+        redisTemplate.execute(bulkSetSequenceScript, keys, args.toArray(new String[0]));
+    }
+
     public Long getSequence(Long roomId) {
         String value = redisTemplate.opsForValue().get(String.format(ROOM_SEQUENCE_KEY, roomId));
         return value == null ? -1L : Long.parseLong(value);
@@ -112,7 +123,7 @@ public class ChatRoomRedisRepository {
         List<Long> result = new ArrayList<>(roomIds.size());
         for (Object val : values) {
             if (val == null) {
-                result.add(0L);
+                result.add(null);
             } else {
                 String strVal = val instanceof byte[] ? new String((byte[]) val) : val.toString();
                 result.add(Long.parseLong(strVal));

--- a/backend/src/main/java/project/backend/global/config/LuaScriptConfig.java
+++ b/backend/src/main/java/project/backend/global/config/LuaScriptConfig.java
@@ -32,6 +32,14 @@ public class LuaScriptConfig {
     }
 
     @Bean
+    public DefaultRedisScript<Void> bulkSetSequenceScript() {
+        DefaultRedisScript<Void> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("scripts/bulk_set_sequence.lua"));
+        script.setResultType(Void.class);
+        return script;
+    }
+
+    @Bean
     public DefaultRedisScript<Long> tokenBucketScript() {
         return loadScript("scripts/token_bucket.lua", Long.class);
     }

--- a/backend/src/main/resources/scripts/bulk_set_sequence.lua
+++ b/backend/src/main/resources/scripts/bulk_set_sequence.lua
@@ -1,0 +1,7 @@
+for i = 1, #KEYS do
+    local cur = redis.call('GET', KEYS[i])
+    if cur == false or tonumber(cur) < tonumber(ARGV[i]) then
+        redis.call('SET', KEYS[i], ARGV[i])
+        redis.call('EXPIRE', KEYS[i], ARGV[#KEYS + i])
+    end
+end


### PR DESCRIPTION
## 🛰️ Issue Number
close #14 

## 🪐 작업 내용
### 변경 사항
- `ChatRoomRedisRepository.getSequences()`: null을 0L 대신 null 그대로 반환
- `ChatRoomSequenceService.getSequences()`: null 감지 시 DB 배치 조회 후 Redis 복구
- `bulk_set_sequence.lua` 추가: 복수 sequence를 RTT 1회로 SET
- `ChatRoomRedisRepository.bulkSetSequences()` 추가
- `ChatRoomRedisService.bulkSetSequences()` 추가

### 고려 사항
- `set_sequence.lua`와 동일하게 `cur < ARGV[i]`일 때만 SET하여 쓰기와의 race condition 방지
- pipeline은 Lua 미지원으로 bulk Lua 스크립트로 대체
- Circuit Breaker fallback은 기존과 동일하게 DB 전체 조회로 처리
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?