### PR TITLE
refactor: 브로드캐스트 유실 복구 방식을 gap 감지에서 재연결 기반으로 변경

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -67,7 +67,7 @@ public class ChatMessageService {
         Member sender = entityManager.getReference(Member.class, memberDetails.getId());
         ChatRoom room = entityManager.getReference(ChatRoom.class, roomId);
 
-        ChatMessage message = createMessage(room, sender, request, seq);
+        ChatMessage message = createMessage(room, sender, request);
         chatMessageRepository.save(message);
 
         String profileImage = profileImageCache.getProfileImage(memberDetails.getId());
@@ -77,14 +77,14 @@ public class ChatMessageService {
     }
 
     private ChatMessage createMessage(ChatRoom room, Member sender,
-                                      ChatMessageRequest request, Long seq) {
+                                      ChatMessageRequest request) {
         return switch (request.getType()) {
             case IMAGE -> {
                 ImageFile findImage = imageFileService.getImageById(request.getImageFileId());
-                yield messageMapper.toEntityWithImage(room, sender, findImage, seq);
+                yield messageMapper.toEntityWithImage(room, sender, findImage);
             }
-            case TEXT -> messageMapper.toEntityWithText(room, sender, request, seq);
-            case CODE -> messageMapper.toEntityWithCode(room, sender, request, seq);
+            case TEXT -> messageMapper.toEntityWithText(room, sender, request);
+            case CODE -> messageMapper.toEntityWithCode(room, sender, request);
             default -> throw new ChatMessageException(ChatMessageErrorCode.INVALID_ROUTE);
         };
     }
@@ -214,8 +214,8 @@ public class ChatMessageService {
         return new ChatScrollResponse(responses, nextCursor);
     }
 
-    public ChatMessage saveJoinEvent(ChatRoom room, Member member, Long seq) {
-        ChatMessage message = messageMapper.toEntityWithJoinEvent(room, member, LocalDateTime.now(), seq);
+    public ChatMessage saveJoinEvent(ChatRoom room, Member member) {
+        ChatMessage message = messageMapper.toEntityWithJoinEvent(room, member, LocalDateTime.now());
         return chatMessageRepository.save(message);
     }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/event/ChatMessageBroadcastEvent.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/event/ChatMessageBroadcastEvent.java
@@ -22,7 +22,6 @@ public record ChatMessageBroadcastEvent(
                 .senderId(sender.getId())
                 .messageId(message.getId())
                 .status(message.getStatus())
-                .sequence(message.getSequence())
                 .build();
 
         return new ChatMessageBroadcastEvent(message.getChatRoom().getId(), response);

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageResponse.java
@@ -20,6 +20,4 @@ public class ChatMessageResponse {
 	private Long senderId;
 	private Long messageId;
 	private MessageStatus status;
-	private Long sequence;
-
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/ChatMessage.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/ChatMessage.java
@@ -61,8 +61,6 @@ public class ChatMessage {
     @Enumerated(EnumType.STRING)
     private MessageStatus status = MessageStatus.NO_CHANGE;
 
-    private Long sequence;
-
     public Long getChatRoomId() {
         return chatRoom.getId();
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
@@ -21,19 +21,18 @@ import project.backend.domain.member.entity.Member;
 public class ChatMessageMapper {
 
     public ChatMessage toEntityWithText(ChatRoom room, Member sender,
-        ChatMessageRequest request, Long sequence) {
+        ChatMessageRequest request) {
         return ChatMessage.builder()
             .chatRoom(room)
             .sender(sender)
             .content(request.getContent())
             .type(MessageType.TEXT)
             .sendAt(LocalDateTime.now())
-            .sequence(sequence)
             .build();
     }
 
     public ChatMessage toEntityWithCode(ChatRoom room, Member sender,
-        ChatMessageRequest request, Long sequence) {
+        ChatMessageRequest request) {
         return ChatMessage.builder()
             .chatRoom(room)
             .sender(sender)
@@ -41,54 +40,49 @@ public class ChatMessageMapper {
             .type(MessageType.CODE)
             .sendAt(LocalDateTime.now())
             .codeLanguage(request.getLanguage())
-            .sequence(sequence)
             .build();
     }
 
     public ChatMessage toEntityWithImage(ChatRoom room, Member sender,
-        ImageFile chatImage, Long sequence) {
+        ImageFile chatImage) {
         return ChatMessage.builder()
             .chatRoom(room)
             .sender(sender)
             .type(MessageType.IMAGE)
             .sendAt(LocalDateTime.now())
             .chatImage(chatImage)
-            .sequence(sequence)
             .build();
     }
 
-    public ChatMessage toEntityWithGit(GitMessageDto gitMessage, Member githubBot, Long sequence) {
+    public ChatMessage toEntityWithGit(GitMessageDto gitMessage, Member githubBot) {
         return ChatMessage.builder()
             .chatRoom(gitMessage.getRoom())
             .type(MessageType.GIT)
             .content(gitMessage.getContent())
             .sendAt(LocalDateTime.now())
             .sender(githubBot)
-            .sequence(sequence)
             .build();
     }
 
     public ChatMessage toEntityWithJoinEvent(ChatRoom room, Member sender,
-        LocalDateTime now, Long sequence) {
+        LocalDateTime now) {
         return ChatMessage.builder()
             .chatRoom(room)
             .sender(sender)
             .content(sender.getNickname() + "님이 입장했습니다.")
             .type(MessageType.EVENT)
             .sendAt(now)
-            .sequence(sequence)
             .build();
     }
 
     public ChatMessage toEntityWithLeaveEvent(ChatRoom room, Member sender,
-        LeaveChatRoomEvent leaveEvent, Long sequence) {
+        LeaveChatRoomEvent leaveEvent) {
         return ChatMessage.builder()
             .chatRoom(room)
             .sender(sender)
             .content(leaveEvent.nickname() + "님이 나갔습니다.")
             .type(MessageType.EVENT)
             .sendAt(leaveEvent.leaveAt())
-            .sequence(sequence)
             .build();
     }
 
@@ -119,7 +113,6 @@ public class ChatMessageMapper {
             .senderId(message.getSender().getId())
             .messageId(message.getId())
             .status(message.getStatus())
-            .sequence(message.getSequence())
             .build();
     }
 
@@ -139,7 +132,6 @@ public class ChatMessageMapper {
             .senderId(memberDetails.getId())
             .messageId(message.getId())
             .status(message.getStatus())
-            .sequence(message.getSequence())
             .build();
     }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomReadService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomReadService.java
@@ -19,23 +19,19 @@ public class ChatRoomReadService {
     private final ChatParticipantRepository chatParticipantRepository;
     private final ChatRoomSequenceService chatRoomSequenceService;
 
-    public List<AllRoomsResponse> findAllRoomsWithUnread(Long memberId,
-                                                         List<ChatRoomWithSequenceProjection> roomProjections,
+    public List<AllRoomsResponse> findAllRoomsWithUnread(List<ChatRoomWithSequenceProjection> roomProjections,
                                                          Map<Long, Boolean> alarmEnabledMap) {
         List<Long> roomIds = new ArrayList<>(roomProjections.size());
         Map<Long, ChatRoomWithSequenceProjection> projectionMap = new HashMap<>();
-        Map<Long, Integer> sequenceIndexMap = new HashMap<>();
 
-        for (int i = 0; i < roomProjections.size(); i++) {
-            ChatRoomWithSequenceProjection p = roomProjections.get(i);
+        for (ChatRoomWithSequenceProjection p : roomProjections) {
             Long id = p.getChatRoomId();
             roomIds.add(id);
             projectionMap.put(id, p);
-            sequenceIndexMap.put(id, i);
         }
 
         List<Long> sortedRoomIds = chatRoomSequenceService.getSortedRoomIds(roomIds);
-        List<Long> sequences = chatRoomSequenceService.getSequences(roomIds);
+        Map<Long, Long> sequenceMap = chatRoomSequenceService.getSequences(roomIds);
 
         return sortedRoomIds.stream().map(roomId -> {
             ChatRoomWithSequenceProjection p = projectionMap.get(roomId);
@@ -43,9 +39,9 @@ public class ChatRoomReadService {
             long lastRead = p.getLastReadSequence() != null ? p.getLastReadSequence() : 0L;
 
             Long unreadCount = null;
-            Integer originalIdx = sequenceIndexMap.get(roomId);
-            if (sequences != null && originalIdx != null) {
-                unreadCount = calculateUnread(lastRead, sequences.get(originalIdx));
+            if (sequenceMap != null) {
+                Long seq = sequenceMap.get(roomId);
+                if (seq != null) unreadCount = calculateUnread(lastRead, seq);
             }
 
             return new AllRoomsResponse(

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
@@ -17,6 +17,7 @@ import project.backend.global.exception.ex.ChatMessageException;
 import project.backend.global.exception.ex.ChatRoomException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -84,13 +85,17 @@ public class ChatRoomSequenceService {
     }
 
     @CircuitBreaker(name = "redis", fallbackMethod = "getSequencesFallback")
-    public List<Long> getSequences(List<Long> roomIds) {
+    public Map<Long, Long> getSequences(List<Long> roomIds) {
         List<Long> sequences = chatRoomRedisService.getSequences(roomIds);
 
+        Map<Long, Long> result = new HashMap<>();
         List<Long> missingRoomIds = new ArrayList<>();
+
         for (int i = 0; i < roomIds.size(); i++) {
             if (sequences.get(i) == null) {
                 missingRoomIds.add(roomIds.get(i));
+            } else {
+                result.put(roomIds.get(i), sequences.get(i));
             }
         }
 
@@ -100,28 +105,17 @@ public class ChatRoomSequenceService {
                     .collect(Collectors.toMap(ChatRoom::getId, ChatRoom::getLastSequence));
 
             chatRoomRedisService.bulkSetSequences(dbSequences);
-
-            for (int i = 0; i < roomIds.size(); i++) {
-                if (sequences.get(i) == null) {
-                    sequences.set(i, dbSequences.getOrDefault(roomIds.get(i), 0L));
-                }
-            }
+            result.putAll(dbSequences);
         }
 
-        return sequences;
+        return result;
     }
 
-    public List<Long> getSequencesFallback(List<Long> roomIds, Throwable e) {
+    public Map<Long, Long> getSequencesFallback(List<Long> roomIds, Throwable e) {
         log.warn("Circuit OPEN - getSequences 폴백");
         meterRegistry.counter("redis.fallback", "reason", "sequence").increment();
-        Map<Long, Long> seqMap = chatRoomRepository.findAllById(roomIds).stream()
-                .collect(Collectors.toMap(
-                        ChatRoom::getId,
-                        ChatRoom::getLastSequence
-                ));
-        return roomIds.stream()
-                .map(id -> seqMap.getOrDefault(id, 0L))
-                .toList();
+        return chatRoomRepository.findAllById(roomIds).stream()
+                .collect(Collectors.toMap(ChatRoom::getId, ChatRoom::getLastSequence));
     }
 
     @CircuitBreaker(name = "redis", fallbackMethod = "getSortedRoomIdsFallback")

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -86,9 +86,9 @@ public class ChatRoomService {
         chatRoomParticipantService.handleParticipantJoin(room, member);
         chatRoomAlarmService.createAlarm(memberId, room.getId());
 
-        Long seq = chatRoomSequenceService.genMessageSeq(room.getId(), memberId);
+        chatRoomSequenceService.genMessageSeq(room.getId(), memberId);
 
-        ChatMessage savedMessage = chatMessageService.saveJoinEvent(room, member, seq);
+        ChatMessage savedMessage = chatMessageService.saveJoinEvent(room, member);
 
         eventPublisher.publishEvent(
                 new JoinChatRoomEvent(room.getId(), memberId, member.getNickname(),
@@ -144,7 +144,7 @@ public class ChatRoomService {
                 ? Collections.emptyMap()
                 : chatRoomAlarmService.findAlarmEnabledMap(memberId, roomIds);
 
-        return chatRoomReadService.findAllRoomsWithUnread(memberId, roomProjections, alarmEnabledMap);
+        return chatRoomReadService.findAllRoomsWithUnread(roomProjections, alarmEnabledMap);
     }
 
     public EntryRoomResponse getEntryInfo(String inviteCode, Long memberId) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
@@ -63,10 +63,10 @@ public class ChatRoomEventListener {
         ChatRoom chatRoom = chatRoomService.getRoomById(leaveEvent.roomId());
         Member member = memberService.getMemberById(leaveEvent.memberId());
 
-        Long seq = chatRoomRedisService.genMessageSeq(leaveEvent.roomId());
+        chatRoomRedisService.genMessageSeq(leaveEvent.roomId());
 
         ChatMessage message = chatMessageMapper.toEntityWithLeaveEvent(chatRoom, member,
-            leaveEvent, seq);
+            leaveEvent);
         ChatMessage savedMessage = chatMessageRepository.save(message);
 
         EventMessageResponse eventMessageResponse = ChatRoomMapper.toLeaveEventMessageResponse(

--- a/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
@@ -68,9 +68,9 @@ public class GitMessageService {
 	private void sendGitMessage(ChatRoom room, GitMessageDto gitMessage) {
 		Member githubBot = memberService.getMemberByUsername(githubUsername);
 
-		Long seq = chatRoomRedisService.genMessageSeq(room.getId());
+		chatRoomRedisService.genMessageSeq(room.getId());
 
-		ChatMessage message = chatMessageMapper.toEntityWithGit(gitMessage, githubBot, seq);
+		ChatMessage message = chatMessageMapper.toEntityWithGit(gitMessage, githubBot);
 		chatMessageRepository.save(message);
 
 		ChatMessageResponse response = chatMessageMapper.toGitResponse(message);

--- a/backend/src/main/java/project/backend/domain/community/app/ApplicantService.java
+++ b/backend/src/main/java/project/backend/domain/community/app/ApplicantService.java
@@ -108,8 +108,8 @@ public class ApplicantService {
 
         chatRoomAlarmService.createAlarm(member.getId(), post.getChatRoom().getId());
 
-        Long seq = chatRoomSequenceService.genMessageSeq(post.getChatRoomId(), requesterId);
-        return chatMessageService.saveJoinEvent(post.getChatRoom(), member, seq);
+        chatRoomSequenceService.genMessageSeq(post.getChatRoomId(), requesterId);
+        return chatMessageService.saveJoinEvent(post.getChatRoom(), member);
     }
 
     private void handleApprove(Post post, Applicant applicant, MemberDetails memberDetails) {

--- a/backend/src/test/java/project/backend/domain/chat/chatmessage/app/ChatMessageServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatmessage/app/ChatMessageServiceTest.java
@@ -101,7 +101,7 @@ class ChatMessageServiceTest {
             given(chatRoomSequenceService.genMessageSeq(10L, 1L)).willReturn(3L);
             given(entityManager.getReference(Member.class, 1L)).willReturn(sender);
             given(entityManager.getReference(ChatRoom.class, 10L)).willReturn(chatRoom);
-            given(messageMapper.toEntityWithText(chatRoom, sender, request, 3L)).willReturn(textMessage);
+            given(messageMapper.toEntityWithText(chatRoom, sender, request)).willReturn(textMessage);
             given(textMessage.getType()).willReturn(TEXT);
 
             given(textMessage.getChatRoom()).willReturn(chatRoom);
@@ -133,7 +133,7 @@ class ChatMessageServiceTest {
 
             ImageFile imageFile = mock(ImageFile.class);
             given(imageFileService.getImageById(99L)).willReturn(imageFile);
-            given(messageMapper.toEntityWithImage(chatRoom, sender, imageFile, 1L)).willReturn(imageMessage);
+            given(messageMapper.toEntityWithImage(chatRoom, sender, imageFile)).willReturn(imageMessage);
             given(imageMessage.getType()).willReturn(IMAGE);
 
             given(imageMessage.getChatRoom()).willReturn(chatRoom);
@@ -159,7 +159,7 @@ class ChatMessageServiceTest {
             given(chatRoomSequenceService.genMessageSeq(10L, 1L)).willReturn(2L);
             given(entityManager.getReference(Member.class, 1L)).willReturn(sender);
             given(entityManager.getReference(ChatRoom.class, 10L)).willReturn(chatRoom);
-            given(messageMapper.toEntityWithCode(chatRoom, sender, request, 2L)).willReturn(codeMessage);
+            given(messageMapper.toEntityWithCode(chatRoom, sender, request)).willReturn(codeMessage);
             given(codeMessage.getType()).willReturn(CODE);
 
             given(codeMessage.getChatRoom()).willReturn(chatRoom);

--- a/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomServiceTest.java
@@ -140,7 +140,7 @@ class ChatRoomServiceTest {
             ChatMessage joinMessage = mock(ChatMessage.class);
             given(joinMessage.getId()).willReturn(500L);
             given(joinMessage.getSendAt()).willReturn(java.time.LocalDateTime.now());
-            given(chatMessageService.saveJoinEvent(chatRoom, joiner, 1L)).willReturn(joinMessage);
+            given(chatMessageService.saveJoinEvent(chatRoom, joiner)).willReturn(joinMessage);
 
             InviteJoinResponse result = chatRoomService.joinChatRoom("INVITE-CODE", 2L);
 
@@ -259,7 +259,7 @@ class ChatRoomServiceTest {
                     .willReturn(Map.of(10L, true));
 
             AllRoomsResponse expected = mock(AllRoomsResponse.class);
-            given(chatRoomReadService.findAllRoomsWithUnread(any(), any(), any()))
+            given(chatRoomReadService.findAllRoomsWithUnread(any(), any()))
                     .willReturn(List.of(expected));
 
             List<AllRoomsResponse> result = chatRoomService.findAllRoomsByMemberId(1L);
@@ -273,7 +273,7 @@ class ChatRoomServiceTest {
         void findAllRooms_empty_returnsEmptyList() {
             given(chatRoomRepository.findAllRoomsWithSequenceByParticipantId(1L))
                     .willReturn(Collections.emptyList());
-            given(chatRoomReadService.findAllRoomsWithUnread(any(), any(), any()))
+            given(chatRoomReadService.findAllRoomsWithUnread(any(), any()))
                     .willReturn(Collections.emptyList());
 
             List<AllRoomsResponse> result = chatRoomService.findAllRoomsByMemberId(1L);

--- a/backend/src/test/java/project/backend/domain/community/app/ApplicantServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/community/app/ApplicantServiceTest.java
@@ -206,7 +206,7 @@ class ApplicantServiceTest {
             given(chatRoomSequenceService.genMessageSeq(10L, 1L)).willReturn(6L); // 수정
 
             ChatMessage joinMessage = mock(ChatMessage.class);
-            given(chatMessageService.saveJoinEvent(chatRoom, applicantMember, 6L)).willReturn(joinMessage);
+            given(chatMessageService.saveJoinEvent(chatRoom, applicantMember)).willReturn(joinMessage);
 
             applicantService.updateStatus(1L, 10L, ApplicantStatus.APPROVED, ownerDetails);
 
@@ -234,10 +234,10 @@ class ApplicantServiceTest {
             given(postRepository.findById(1L)).willReturn(Optional.of(post));
             given(applicantRepository.findById(10L)).willReturn(Optional.of(applicant));
             given(chatRoomReadService.getLatestSequence(10L)).willReturn(3L);
-            given(chatRoomSequenceService.genMessageSeq(10L, 1L)).willReturn(4L); // 수정
+            given(chatRoomSequenceService.genMessageSeq(10L, 1L)).willReturn(4L);
 
             ChatMessage joinMessage = mock(ChatMessage.class);
-            given(chatMessageService.saveJoinEvent(chatRoom, applicantMember, 4L)).willReturn(joinMessage);
+            given(chatMessageService.saveJoinEvent(chatRoom, applicantMember)).willReturn(joinMessage);
 
             applicantService.updateStatus(1L, 10L, ApplicantStatus.APPROVED, ownerDetails);
 

--- a/frontend/src/context/AlarmContext.jsx
+++ b/frontend/src/context/AlarmContext.jsx
@@ -40,7 +40,6 @@ export const AlarmProvider = ({ children }) => {
   }, [])
 
   const incrementUnread = useCallback((roomUniqueId) => {
-    console.trace('incrementUnread 호출 roomId=', roomUniqueId)
     setAlarmRooms(prev => prev.map(r =>
       Number(r.uniqueId) === Number(roomUniqueId)
         ? { ...r, unreadCount: (r.unreadCount ?? 0) + 1 }


### PR DESCRIPTION
## 🛰️ Issue Number
close #17 

## 🪐 작업 내용
#### 배경
기존에는 메시지 수신 시 sequence gap을 감지하여
누락된 메시지를 즉시 API로 복구하는 방식을 사용했습니다.

#### 문제
Redis 복구 시점에 접속 중인 모든 클라이언트가
동시에 gap을 감지하고 fetchMissingMessages API를 호출하여
DB에 대량 요청이 집중되는 문제가 있었습니다.

#### 변경 사항
- WebSocket 재연결 시 fetchMissingMessages를 호출하여
  누락 구간을 보정하는 방식으로 변경
- ChatMessageResponse, ChatMessage 엔티티에서 sequence 필드 제거
- ChatMessageMapper, ChatMessageService에서 seq 관련 코드 제거
- ChatRoom.js에서 lastSequenceRef 및 gap 감지 로직 제거
- prevConnectedRef 추가하여 재연결 시점 감지

#### trade-off
실시간 gap 감지에서 재연결 기반 보정으로 변경하면서
WebSocket이 끊기지 않는 구간에서 브로드캐스트 유실이 발생해도
즉각 감지하지 못하는 한계가 있습니다.
다만 채팅은 완벽한 실시간 정합성보다 최종적 일관성이
더 중요한 도메인이라고 판단하여 이 방식을 선택했습니다.


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?