### PR TITLE
feat: logout, 비정상 연결(SessionDisconnectEvent)시 사용자 메시지 개수 동기화 구현

### DIFF
--- a/backend/src/main/java/project/backend/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/project/backend/global/config/WebSocketConfig.java
@@ -17,7 +17,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
 import project.backend.global.security.handler.JwtHandshakeHandler;
-import project.backend.global.security.interceptor.StompHandler;
+import project.backend.global.security.handler.StompHandler;
 import project.backend.global.security.interceptor.WebSocketHandShakeInterceptor;
 
 @Configuration

--- a/backend/src/main/java/project/backend/global/security/handler/StompDisconnectHandler.java
+++ b/backend/src/main/java/project/backend/global/security/handler/StompDisconnectHandler.java
@@ -1,0 +1,39 @@
+package project.backend.global.security.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import project.backend.domain.chat.chatroom.app.ChatRoomReadService;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompDisconnectHandler {
+
+    private final ChatRoomReadService chatRoomReadService;
+
+    @EventListener
+    public void handleDisconnect(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+
+        if (sessionAttributes == null) return;
+
+        Long roomId = (Long) sessionAttributes.get("currentRoomId");
+        Long memberId = (Long) sessionAttributes.get("memberId");
+
+        if (roomId == null || memberId == null) return;
+
+        try {
+            chatRoomReadService.updateLastReadSequence(roomId, memberId);
+            log.info("비정상 종료 안읽음 동기화 완료 - memberId: {}, roomId: {}", memberId, roomId);
+        } catch (Exception e) {
+            log.warn("비정상 종료 안읽음 동기화 실패 - memberId: {}, roomId: {}", memberId, roomId);
+        }
+    }
+}

--- a/backend/src/main/java/project/backend/global/security/handler/StompHandler.java
+++ b/backend/src/main/java/project/backend/global/security/handler/StompHandler.java
@@ -1,4 +1,4 @@
-package project.backend.global.security.interceptor;
+package project.backend.global.security.handler;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
@@ -50,6 +50,10 @@ public class StompHandler implements ChannelInterceptor {
             if (!exists) {
                 throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
             }
+
+            accessor.getSessionAttributes().put("currentRoomId", roomId);
+            accessor.getSessionAttributes().put("memberId", memberId);
+
         }
 
         return message;

--- a/frontend/src/components/header.jsx
+++ b/frontend/src/components/header.jsx
@@ -7,12 +7,14 @@ import styles from "./header.module.css"
 import axiosInstance from "./api/axiosInstance"
 import { Link } from "react-router-dom"
 import { useUser } from '../context/UserContext'
+import { useAlarm } from '../context/AlarmContext'
 import useWebSocketNotifications from "./common/useWebSocket"
 
 window.__devchatActiveNoti ??= null;
 
 export function HeaderWithNotifications() {
   const { currentUser, isLoading } = useUser()
+  const { currentRoomId } = useAlarm()
 
   const [isProfileOpen, setIsProfileOpen] = useState(false)
   const profileDropdownRef = useRef(null)
@@ -432,6 +434,25 @@ export function HeaderWithNotifications() {
     fetchNotifications(0, true, newFilter)
   }
 
+  const handleLogout = async () => {
+    try {
+      // 현재 채팅방에 있으면 안읽음 카운트 동기화
+      if (currentRoomId) {
+        await axiosInstance.post(`/chat-rooms/${currentRoomId}/read`).catch(() => {})
+      }
+      const response = await axiosInstance.post("/logout", {})
+      if (response.status === 204) {
+        alert("로그아웃 되었습니다.")
+        window.location.href = "/login"
+      } else {
+        alert("로그아웃 실패")
+      }
+    } catch (error) {
+      console.error("로그아웃 요청 실패:", error)
+      alert("서버 오류로 로그아웃 실패")
+    }
+  }
+
   const displayCount = unreadNotificationCount + realtimeNotificationCount
 
   useEffect(() => {
@@ -590,20 +611,7 @@ export function HeaderWithNotifications() {
                   <div className={styles.profileDropdownDivider} />
                   <button
                     className={`${styles.profileDropdownItem} ${styles.profileDropdownLogout}`}
-                    onClick={async () => {
-                      try {
-                        const response = await axiosInstance.post("/logout", {})
-                        if (response.status === 204) {
-                          alert("로그아웃 되었습니다.")
-                          window.location.href = "/login"
-                        } else {
-                          alert("로그아웃 실패")
-                        }
-                      } catch (error) {
-                        console.error("로그아웃 요청 실패:", error)
-                        alert("서버 오류로 로그아웃 실패")
-                      }
-                    }}
+                    onClick={handleLogout}
                   >
                     <span className={styles.profileDropdownIcon}>🚪</span>
                     로그아웃


### PR DESCRIPTION
## 🛰️ Issue Number
close #23 

## 🪐 작업 내용
### 1. 로그아웃 시
- ChatRoom cleanup 함수에만 의존하고 있어
  명시적인 동기화 보장이 없음
- 네트워크 불안정 상태에서 로그아웃 시
  cleanup 함수가 실행되지 않을 수 있음

### 2. 비정상 종료 시
- 앱 강제 종료, 네트워크 끊김 등으로
  클라이언트가 /read API를 호출할 수 없는 상황에서
  lastReadSequence 동기화 안됨

## 변경 사항

### 로그아웃 시 명시적 동기화
- Header.jsx 로그아웃 전 currentRoomId가 있으면
  `/chat-rooms/{roomId}/read` API를 명시적으로 호출

### 비정상 종료 시 서버 측 동기화
- StompHandler SUBSCRIBE 시 세션 attributes에
  currentRoomId, memberId 저장
- StompDisconnectHandler 추가
  SessionDisconnectEvent 감지 시
  updateLastReadSequence() 직접 호출

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?