### PR TITLE
refactor: 메모리 최적화

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 
 # 실행
-ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -Dspring.profiles.active=prod -jar app.jar"]

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
@@ -1,12 +1,11 @@
 package project.backend.domain.chat.chatmessage.dao;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchProjection;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
@@ -20,15 +19,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     List<ChatMessage> findByChatRoom_IdAndIdLessThanOrderByIdDesc(Long roomId, Long cursor,
         Pageable pageable);
 
-    @Query("""
-        SELECT cm FROM ChatMessage cm
-        LEFT JOIN ChatMessageSearch cms ON cm.id = cms.id
-        WHERE cm.createdAt > :from
-        AND cms.id IS NULL
-        """)
-    List<ChatMessage> findMissingSearchIndex(@Param("from") LocalDateTime from, Pageable pageable);
-
-    Optional<ChatMessage> findTopByChatRoom_IdOrderByIdDesc(Long roomId);
-
     void deleteByChatRoom_Id(Long chatRoomId);
+
+    @Query("SELECT m.id as id, m.content as content, m.chatRoom.id as chatRoomId FROM ChatMessage m WHERE m.id IN :ids")
+    List<ChatMessageSearchProjection> findSearchDataByIdIn(@Param("ids") List<Long> ids);
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchProjection.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchProjection.java
@@ -1,0 +1,7 @@
+package project.backend.domain.chat.chatmessage.dto;
+
+public interface ChatMessageSearchProjection {
+    Long getId();
+    String getContent();
+    Long getChatRoomId();
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import project.backend.auth.dto.MemberDetails;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageResponse;
+import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchProjection;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
 import project.backend.domain.chat.chatmessage.dto.event.ChatMessageBroadcastEvent;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
@@ -88,13 +89,12 @@ public class ChatMessageMapper {
             .build();
     }
 
-    // 저장된 메시지에서 ID, roomId, content만 꺼내서 저장하므로 ChatMessage 사용
-    public ChatMessageSearch toSearchEntity(ChatMessage message) {
+    public ChatMessageSearch toSearchEntity(ChatMessageSearchProjection projection) {
         return ChatMessageSearch.builder()
-            .id(message.getId())
-            .roomId(message.getChatRoom().getId())
-            .content(message.getContent())
-            .build();
+                .id(projection.getId())
+                .roomId(projection.getChatRoomId())
+                .content(projection.getContent())
+                .build();
     }
 
     public ChatMessageResponse toResponse(ChatMessage message) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
-import project.backend.domain.community.entity.Post;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,9 +39,6 @@ public class ChatRoom {
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatParticipant> participants = new ArrayList<>();
-
-    @OneToOne(mappedBy = "chatRoom")
-    private Post post;
 
     @Column(name = "last_sequence", nullable = false)
     private Long lastSequence = 0L;

--- a/backend/src/main/java/project/backend/domain/chat/chatsearch/app/ChatMessageSearchScheduler.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatsearch/app/ChatMessageSearchScheduler.java
@@ -37,7 +37,7 @@ public class ChatMessageSearchScheduler {
                 .map(ChatMessageIndexStatus::getMessageId)
                 .toList();
 
-        List<ChatMessageSearch> searchList = chatMessageRepository.findByIdIn(messageIds)
+        List<ChatMessageSearch> searchList = chatMessageRepository.findSearchDataByIdIn(messageIds)
                 .stream()
                 .map(messageMapper::toSearchEntity)
                 .toList();

--- a/backend/src/test/java/project/backend/domain/chat/chatsearch/ChatMessageSearchSchedulerTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatsearch/ChatMessageSearchSchedulerTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
+import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchProjection;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
 import project.backend.domain.chat.chatmessage.dao.ChatMessageIndexStatusRepository;
@@ -49,7 +50,7 @@ class ChatMessageSearchSchedulerTest {
 
             scheduler.processSearchIndex();
 
-            then(chatMessageRepository).should(never()).findByIdIn(anyList());
+            then(chatMessageRepository).should(never()).findSearchDataByIdIn(anyList());
             then(bulkRepository).should(never()).bulkInsertIgnore(anyList());
             then(indexStatusRepository).should(never()).deleteAll(anyList());
         }
@@ -61,16 +62,16 @@ class ChatMessageSearchSchedulerTest {
             given(status.getMessageId()).willReturn(1L);
             given(indexStatusRepository.findTop100ByOrderByMessageIdAsc()).willReturn(List.of(status));
 
-            ChatMessage message = mock(ChatMessage.class);
-            given(chatMessageRepository.findByIdIn(List.of(1L))).willReturn(List.of(message));
+            ChatMessageSearchProjection projection = mock(ChatMessageSearchProjection.class);
+            given(chatMessageRepository.findSearchDataByIdIn(List.of(1L))).willReturn(List.of(projection));
 
             ChatMessageSearch search = mock(ChatMessageSearch.class);
-            given(messageMapper.toSearchEntity(message)).willReturn(search);
+            given(messageMapper.toSearchEntity(projection)).willReturn(search);
 
             scheduler.processSearchIndex();
 
             then(bulkRepository).should().bulkInsertIgnore(List.of(search));
-            then(indexStatusRepository).should().deleteAll(List.of(status));
+            then(indexStatusRepository).should().deleteAllByMessageIdIn(List.of(1L));
         }
 
         @Test
@@ -80,11 +81,11 @@ class ChatMessageSearchSchedulerTest {
             given(status.getMessageId()).willReturn(1L);
             given(indexStatusRepository.findTop100ByOrderByMessageIdAsc()).willReturn(List.of(status));
 
-            ChatMessage message = mock(ChatMessage.class);
-            given(chatMessageRepository.findByIdIn(List.of(1L))).willReturn(List.of(message));
+            ChatMessageSearchProjection projection = mock(ChatMessageSearchProjection.class);
+            given(chatMessageRepository.findSearchDataByIdIn(List.of(1L))).willReturn(List.of(projection));
 
             ChatMessageSearch search = mock(ChatMessageSearch.class);
-            given(messageMapper.toSearchEntity(message)).willReturn(search);
+            given(messageMapper.toSearchEntity(projection)).willReturn(search);
 
             willThrow(new RuntimeException("DB 오류")).given(bulkRepository).bulkInsertIgnore(anyList());
 
@@ -103,11 +104,11 @@ class ChatMessageSearchSchedulerTest {
             given(status.getMessageId()).willReturn(1L);
             given(indexStatusRepository.findTop100ByOrderByMessageIdAsc()).willReturn(List.of(status));
 
-            ChatMessage message = mock(ChatMessage.class);
-            given(chatMessageRepository.findByIdIn(List.of(1L))).willReturn(List.of(message));
+            ChatMessageSearchProjection projection = mock(ChatMessageSearchProjection.class);
+            given(chatMessageRepository.findSearchDataByIdIn(List.of(1L))).willReturn(List.of(projection));
 
             ChatMessageSearch search = mock(ChatMessageSearch.class);
-            given(messageMapper.toSearchEntity(message)).willReturn(search);
+            given(messageMapper.toSearchEntity(projection)).willReturn(search);
 
             willThrow(new RuntimeException("DB 오류")).given(bulkRepository).bulkInsertIgnore(anyList());
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     ports:
       - "8081:8080"
     environment:
+      - JAVA_OPTS=-Xms256m -Xmx384m
       - TZ=Asia/Seoul
       - JWT_SECRET=${JWT_SECRET}
       - RDS_USERNAME=${RDS_USERNAME}
@@ -38,6 +39,7 @@ services:
     ports:
       - "8082:8080"
     environment:
+      - JAVA_OPTS=-Xms256m -Xmx384m
       - TZ=Asia/Seoul
       - JWT_SECRET=${JWT_SECRET}
       - RDS_USERNAME=${RDS_USERNAME}


### PR DESCRIPTION
## 🛰️ Issue Number
close #33

## 🪐 작업 내용

### perf: ChatMessageSearch 스케줄러 프로젝션 적용
- 5초마다 실행되는 `ChatMessageSearchScheduler`에서 `ChatMessage` 전체 엔티티 조회 시 `Member`, `ChatRoom`, `Post` 연관 객체까지 EAGER 로딩되는 문제 개선
- 검색 인덱싱에 필요한 `id`, `content`, `roomId`만 프로젝션으로 조회하도록 변경
- 스케줄러 실행 시 불필요한 `chat_room`, `post`, `member` 조인 쿼리 제거

### refactor: ChatRoom - Post 단방향 연관관계로 변경
- `ChatRoom`에서 `Post`를 참조하는 `@OneToOne` 필드가 실제로 사용되지 않아 제거
- `ChatRoom` 조회 시 불필요한 `post` 조인 제거

### chore: 미사용 쿼리 메서드 제거
- `findMissingSearchIndex` 메서드 제거 (아웃박스 패턴으로 이미 커버됨)

### chore: 컨테이너 힙 메모리 제한 설정
- Blue/Green 배포 시 두 컨테이너가 동시에 뜨는 순간 OOM 위험 방지
- `Dockerfile` ENTRYPOINT에 `JAVA_OPTS` 적용
- `docker-compose.yml` blue, green 컨테이너에 `-Xms256m -Xmx384m` 설정

## 📚 Reference
- VisualVM으로 로컬 힙 모니터링 후 문제 발견
- Grafana로 운영 서버 메모리 패턴 분석

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?