### PR TITLE
feat: 채팅방 참여 인원 제한 및 비관적 락 적용

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
@@ -30,6 +30,9 @@ public class ChatRoomParticipantService {
     private final ApplicationEventPublisher eventPublisher;
 
     public void handleParticipantJoin(ChatRoom room, Member member) {
+
+        validateJoinConstraints(room, member);
+
         Optional<ChatParticipant> existingParticipant =
                 chatParticipantRepository.findByChatRoomIdAndParticipantId(
                         room.getId(), member.getId());
@@ -43,6 +46,15 @@ public class ChatRoomParticipantService {
         } else {
             ChatParticipant chatParticipant = ChatParticipant.of(member, room);
             room.addParticipant(chatParticipant);
+        }
+    }
+
+    private void validateJoinConstraints(ChatRoom room, Member member) {
+        if (chatParticipantRepository.countByParticipantIdAndIsActiveTrue(member.getId()) >= 50) {
+            throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_LIMIT_EXCEEDED);
+        }
+        if (chatParticipantRepository.countByChatRoomIdAndIsActiveTrue(room.getId()) >= 50) {
+            throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_FULL);
         }
     }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
@@ -26,6 +26,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ChatRoomParticipantService {
 
+    private static final int MAX_ROOMS_PER_MEMBER = 50;
+    private static final int MAX_PARTICIPANTS_PER_ROOM = 50;
+
     private final ChatParticipantRepository chatParticipantRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -50,10 +53,10 @@ public class ChatRoomParticipantService {
     }
 
     private void validateJoinConstraints(ChatRoom room, Member member) {
-        if (chatParticipantRepository.countByParticipantIdAndIsActiveTrue(member.getId()) >= 50) {
+        if (chatParticipantRepository.countByParticipantIdAndIsActiveTrue(member.getId()) >= MAX_ROOMS_PER_MEMBER) {
             throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_LIMIT_EXCEEDED);
         }
-        if (chatParticipantRepository.countByChatRoomIdAndIsActiveTrue(room.getId()) >= 50) {
+        if (chatParticipantRepository.countByChatRoomIdAndIsActiveTrue(room.getId()) >= MAX_PARTICIPANTS_PER_ROOM) {
             throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_FULL);
         }
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
@@ -18,7 +18,6 @@ import project.backend.global.exception.ex.ChatRoomException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -26,8 +25,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ChatRoomParticipantService {
 
-    private static final int MAX_ROOMS_PER_MEMBER = 50;
-    private static final int MAX_PARTICIPANTS_PER_ROOM = 50;
+    private static final int MAX_ROOMS_PER_MEMBER = 3;
+    private static final int MAX_PARTICIPANTS_PER_ROOM = 3;
 
     private final ChatParticipantRepository chatParticipantRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -56,7 +55,7 @@ public class ChatRoomParticipantService {
         if (chatParticipantRepository.countByParticipantIdAndIsActiveTrue(member.getId()) >= MAX_ROOMS_PER_MEMBER) {
             throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_LIMIT_EXCEEDED);
         }
-        if (chatParticipantRepository.countByChatRoomIdAndIsActiveTrue(room.getId()) >= MAX_PARTICIPANTS_PER_ROOM) {
+        if (chatParticipantRepository.countByChatRoomIdAndIsActiveTrueWithLock(room.getId()) >= MAX_PARTICIPANTS_PER_ROOM) {
             throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_FULL);
         }
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -2,9 +2,13 @@ package project.backend.domain.chat.chatroom.dao;
 
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
@@ -34,6 +38,8 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
     int countByParticipantIdAndIsActiveTrue(Long participantId);
 
-    int countByChatRoomIdAndIsActiveTrue(Long chatRoomId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT COUNT(cp) FROM ChatParticipant cp WHERE cp.chatRoom.id = :chatRoomId AND cp.isActive = true")
+    int countByChatRoomIdAndIsActiveTrueWithLock(@Param("chatRoomId") Long chatRoomId);
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -31,5 +31,9 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     boolean existsByParticipantIdAndChatRoomIdAndIsActiveTrue(Long participantId, Long chatRoomId);
 
     void deleteByChatRoom_Id(Long chatRoomId);
+
+    int countByParticipantIdAndIsActiveTrue(Long participantId);
+
+    int countByChatRoomIdAndIsActiveTrue(Long chatRoomId);
 }
 

--- a/backend/src/main/java/project/backend/global/exception/errorcode/ChatRoomErrorCode.java
+++ b/backend/src/main/java/project/backend/global/exception/errorcode/ChatRoomErrorCode.java
@@ -20,7 +20,9 @@ public enum ChatRoomErrorCode implements ErrorCode {
     ASYNC_TASK_REJECTED("CRE-010", "작업량이 많아 요청이 처리되지 않았습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
     ALARM_NOT_FOUND("CRE-011", "채팅방 알림 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     TOO_MANY_REQUESTS("CRE-012", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
-    SERVICE_UNAVAILABLE("CRE-013", "서비스가 일시적으로 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE);
+    SERVICE_UNAVAILABLE("CRE-013", "서비스가 일시적으로 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE),
+    CHATROOM_FULL("CRE-014", "채팅방 인원이 가득 찼습니다.", HttpStatus.CONFLICT),
+    CHATROOM_LIMIT_EXCEEDED("CRE-015", "참여 가능한 채팅방 수를 초과했습니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/frontend/src/pages/BlankRoom.jsx
+++ b/frontend/src/pages/BlankRoom.jsx
@@ -39,21 +39,18 @@ const BlankRoom = () => {
 
 
   // 채팅방 참여 핸들러
-   const handleJoinRoom = async (inviteCode) => {
+  const handleJoinRoom = async (inviteCode) => {
     try {
-      const res = await axiosInstance.post('/chat-rooms/join', {
-        inviteCode
-      });
-      
+      const res = await axiosInstance.post('/chat-rooms/join', { inviteCode });
       const data = res.data;
       setShowJoinModal(false);
-      
       navigate(`/chat/${data.inviteCode}`);
+      window.dispatchEvent(new Event('room:read'))  // 사이드바 갱신 트리거
     } catch (err) {
       alert(err.response?.data?.message || err.message || "방 입장에 실패했습니다.");
       throw err;
     }
-  };  
+  };
   // 버튼 스타일 공통화
   const buttonStyle = {
     color: 'white',


### PR DESCRIPTION
## 🛰️ Issue Number
close #35 

## 🪐 작업 내용

### 배경
채팅방 참여 인원이 50명인 상태에서 동시에 2명이 입장을 시도하면 둘 다 49명으로 조회해 검증을 통과하고 51명이 되는 race condition이 발생할 수 있다.

### 시나리오
```
채팅방 인원 49명 상태

스레드 A (사용자 1 입장 시도)
  countByChatRoomId 조회 → 49명 확인 → 검증 통과

스레드 B (사용자 2 동시 입장 시도)
  countByChatRoomId 조회 → 49명 확인 → 검증 통과

둘 다 INSERT → 51명 입 발생 (50명 제한 위반)
```

### 낙관적 락을 선택하지 않은 이유
```
낙관적 락 (@Version)
→ ChatRoom 엔티티에 version 필드 추가 필요
→ 폴백 시, 메시지 전송마다 last_sequence를 업데이트하는데 매번 version이 올라감
→ 입장 시도 중 채팅이 발생하면 version 불일치로 OptimisticLockException 발생
→ 채팅이 활발할수록 입장 실패 빈도 증가
```

### 비관적 락 선택 이유
```
채팅방 입장은 충돌 빈도 낙음
→ 충돌 시에만 대기하는 비용 발생
→ chat_participant 카운트 조회에만 스코프 한정
→ ChatRoom 엔티티 수정 없음 → 안전
```

### 변경 사항
- `countByChatRoomIdAndIsActiveTrueWithLock` 쿼리 메서드 추가
- `validateJoinConstraints` 메서드로 검증 로직 분리
- `MAX_ROOMS_PER_MEMBER`, `MAX_PARTICIPANTS_PER_ROOM` 상수 분리
- `ChatRoomErrorCode` `CHATROOM_FULL`, `CHATROOM_LIMIT_EXCEEDED` 추가

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?