### PR TITLE
chore: Redis Sentinel 설정 파일 추가 및 AOF 최적화

### DIFF
--- a/redis-sentinel/docker-compose.yml
+++ b/redis-sentinel/docker-compose.yml
@@ -1,0 +1,103 @@
+version: "3"
+
+services:
+  redis1:
+    image: redis:7
+    container_name: redis1
+    command: redis-server /usr/local/etc/redis/redis1.conf
+    volumes:
+      - ./redis/redis1.conf:/usr/local/etc/redis/redis1.conf
+      - redis1-data:/data
+    ports:
+      - "6379:6379"
+    networks:
+      redis-net:
+        ipv4_address: 172.20.0.11
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 5
+
+  redis2:
+    image: redis:7
+    container_name: redis2
+    command: redis-server /usr/local/etc/redis/redis2.conf
+    volumes:
+      - ./redis/redis2.conf:/usr/local/etc/redis/redis2.conf
+      - redis2-data:/data
+    ports:
+      - "6380:6380"
+    networks:
+      redis-net:
+        ipv4_address: 172.20.0.12
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6380", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 5
+
+  sentinel1:
+    image: redis:7
+    container_name: sentinel1
+    command: redis-sentinel /usr/local/etc/sentinel/sentinel1.conf
+    volumes:
+      - ./sentinel:/usr/local/etc/sentinel
+      - ./scripts:/scripts
+    ports:
+      - "26379:26379"
+    networks:
+      redis-net:
+        ipv4_address: 172.20.0.21
+    depends_on:
+      redis1:
+        condition: service_healthy
+      redis2:
+        condition: service_healthy
+
+  sentinel2:
+    image: redis:7
+    container_name: sentinel2
+    command: redis-sentinel /usr/local/etc/sentinel/sentinel2.conf
+    volumes:
+      - ./sentinel:/usr/local/etc/sentinel
+      - ./scripts:/scripts
+    ports:
+      - "26380:26379"
+    networks:
+      redis-net:
+        ipv4_address: 172.20.0.22
+    depends_on:
+      redis1:
+        condition: service_healthy
+      redis2:
+        condition: service_healthy
+
+  sentinel3:
+    image: redis:7
+    container_name: sentinel3
+    command: redis-sentinel /usr/local/etc/sentinel/sentinel3.conf
+    volumes:
+      - ./sentinel:/usr/local/etc/sentinel
+      - ./scripts:/scripts
+    ports:
+      - "26381:26379"
+    networks:
+      redis-net:
+        ipv4_address: 172.20.0.23
+    depends_on:
+      redis1:
+        condition: service_healthy
+      redis2:
+        condition: service_healthy
+
+networks:
+  redis-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+
+volumes:
+  redis1-data:
+  redis2-data:

--- a/redis-sentinel/redis/redis1.conf
+++ b/redis-sentinel/redis/redis1.conf
@@ -1,0 +1,7 @@
+port 6379
+dir /data
+appendonly no
+protected-mode no
+
+maxmemory 256mb
+maxmemory-policy noeviction

--- a/redis-sentinel/redis/redis2.conf
+++ b/redis-sentinel/redis/redis2.conf
@@ -1,0 +1,8 @@
+port 6380
+dir /data
+appendonly yes
+protected-mode no
+replicaof 172.20.0.11 6379
+
+maxmemory 256mb
+maxmemory-policy noeviction

--- a/redis-sentinel/scripts/reconfig.sh
+++ b/redis-sentinel/scripts/reconfig.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+ROLE=$2
+NEW_MASTER_IP=$6
+NEW_MASTER_PORT=$7
+OLD_MASTER_IP=$4
+OLD_MASTER_PORT=$5
+
+if [ "$ROLE" == "leader" ]; then
+    redis-cli -h $NEW_MASTER_IP -p $NEW_MASTER_PORT CONFIG SET appendonly no
+    redis-cli -h $NEW_MASTER_IP -p $NEW_MASTER_PORT CONFIG REWRITE
+
+    redis-cli -h $OLD_MASTER_IP -p $OLD_MASTER_PORT CONFIG SET appendonly yes
+    redis-cli -h $OLD_MASTER_IP -p $OLD_MASTER_PORT CONFIG REWRITE
+fi

--- a/redis-sentinel/sentinel/sentinel1.conf
+++ b/redis-sentinel/sentinel/sentinel1.conf
@@ -1,0 +1,5 @@
+port 26379
+sentinel monitor mymaster 172.20.0.11 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 10000
+sentinel client-reconfig-script mymaster /scripts/reconfig.sh

--- a/redis-sentinel/sentinel/sentinel2.conf
+++ b/redis-sentinel/sentinel/sentinel2.conf
@@ -1,0 +1,5 @@
+port 26380
+sentinel monitor mymaster 172.20.0.11 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 10000
+sentinel client-reconfig-script mymaster /scripts/reconfig.sh

--- a/redis-sentinel/sentinel/sentinel3.conf
+++ b/redis-sentinel/sentinel/sentinel3.conf
@@ -1,0 +1,5 @@
+port 26381
+sentinel monitor mymaster 172.20.0.11 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 10000
+sentinel client-reconfig-script mymaster /scripts/reconfig.sh


### PR DESCRIPTION
## 🛰️ Issue Number
close #37 

## 🪐 작업 내용
### 개요
EC2 로컬에만 존재하던 Redis Sentinel 설정 파일을 레포에 추가하고
AOF 설정을 최적화합니다.

### 변경 사항
- `redis1.conf` - 마스터 AOF off (쓰기 성능 최적화)
- `redis2.conf` - 레플리카 AOF on + replicaof 영구 설정 추가
- `reconfig.sh` - Failover 시 AOF 자동 전환 스크립트
- `sentinel.conf` - client-reconfig-script 추가
- `docker-compose.yml` - scripts 볼륨 마운트 추가

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?