### PR TITLE
fix: 메시지 인서트 최적화와 채팅방 참여 락 스코프 변경

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -68,7 +68,7 @@ public class ChatMessageService {
         chatMessageRepository.save(message);
 
         if (isSearchable(message)) {
-            chatMessageIndexStatusRepository.save(messageMapper.toIndexStatus(message));
+            entityManager.persist(messageMapper.toIndexStatus(message));
         }
         publishEvents(message, memberDetails);
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
@@ -32,7 +32,6 @@ public class ChatRoomParticipantService {
     private final ApplicationEventPublisher eventPublisher;
 
     public void handleParticipantJoin(ChatRoom room, Member member) {
-
         validateJoinConstraints(room, member);
 
         Optional<ChatParticipant> existingParticipant =
@@ -52,10 +51,13 @@ public class ChatRoomParticipantService {
     }
 
     private void validateJoinConstraints(ChatRoom room, Member member) {
-        if (chatParticipantRepository.countByParticipantIdAndIsActiveTrue(member.getId()) >= MAX_ROOMS_PER_MEMBER) {
+
+        if (chatParticipantRepository.countByParticipantIdAndIsActiveTrue(member.getId())
+                >= MAX_ROOMS_PER_MEMBER) {
             throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_LIMIT_EXCEEDED);
         }
-        if (chatParticipantRepository.countByChatRoomIdAndIsActiveTrueWithLock(room.getId()) >= MAX_PARTICIPANTS_PER_ROOM) {
+        if (chatParticipantRepository.countByChatRoomIdAndIsActiveTrue(room.getId())
+                >= MAX_PARTICIPANTS_PER_ROOM) {
             throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_FULL);
         }
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -3,6 +3,8 @@ package project.backend.domain.chat.chatroom.app;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -80,22 +82,39 @@ public class ChatRoomService {
     @Transactional
     public InviteJoinResponse joinChatRoom(String inviteCode, Long memberId) {
         log.info("timetrace 적용");
-        ChatRoom room = getByInviteCode(inviteCode);
-        Member member = memberService.getMemberById(memberId);
+        try {
+            ChatRoom room = getByInviteCodeWithLock(inviteCode);
+            Member member = memberService.getMemberById(memberId);
 
-        chatRoomParticipantService.handleParticipantJoin(room, member);
-        chatRoomAlarmService.createAlarm(memberId, room.getId());
+            chatRoomParticipantService.handleParticipantJoin(room, member);
 
-        chatRoomSequenceService.genMessageSeq(room.getId());
+            chatRoomAlarmService.createAlarm(memberId, room.getId());
+            chatRoomSequenceService.genMessageSeq(room.getId());
 
-        ChatMessage savedMessage = chatMessageService.saveJoinEvent(room, member);
+            ChatMessage savedMessage = chatMessageService.saveJoinEvent(room, member);
 
-        eventPublisher.publishEvent(
-                new JoinChatRoomEvent(room.getId(), memberId, member.getNickname(),
-                        savedMessage.getId(), savedMessage.getCreatedAt()));
+            eventPublisher.publishEvent(
+                    new JoinChatRoomEvent(
+                            room.getId(),
+                            memberId,
+                            member.getNickname(),
+                            savedMessage.getId(),
+                            savedMessage.getCreatedAt()
+                    )
+            );
+            return ChatRoomMapper.toInviteJoinResponse(
+                    room.getId(),
+                    room.getInviteCode(),
+                    room.getName()
+            );
+        } catch (PessimisticLockException | LockTimeoutException e) {
+            throw new ChatRoomException(ChatRoomErrorCode.TRY_AGAIN);
+        }
+    }
 
-        return ChatRoomMapper.toInviteJoinResponse(room.getId(), room.getInviteCode(),
-                room.getName());
+    private ChatRoom getByInviteCodeWithLock(String inviteCode) {
+        return chatRoomRepository.findByInviteCodeWithLock(inviteCode)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
     }
 
     public String getRecentRoomInviteCode(Long memberId) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -3,12 +3,9 @@ package project.backend.domain.chat.chatroom.dao;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
@@ -38,8 +35,6 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
     int countByParticipantIdAndIsActiveTrue(Long participantId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT COUNT(cp) FROM ChatParticipant cp WHERE cp.chatRoom.id = :chatRoomId AND cp.isActive = true")
-    int countByChatRoomIdAndIsActiveTrueWithLock(@Param("chatRoomId") Long chatRoomId);
+    int countByChatRoomIdAndIsActiveTrue(Long chatRoomId);
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -2,11 +2,12 @@ package project.backend.domain.chat.chatroom.dao;
 
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 
@@ -23,6 +24,13 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         Pageable pageable);
 
     Optional<ChatRoom> findByInviteCode(String inviteCode);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+            @QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")
+    })
+    @Query("SELECT r FROM ChatRoom r WHERE r.inviteCode = :inviteCode")
+    Optional<ChatRoom> findByInviteCodeWithLock(@Param("inviteCode") String inviteCode);
 
     @Query("""
         SELECT cr

--- a/backend/src/main/java/project/backend/global/exception/errorcode/ChatRoomErrorCode.java
+++ b/backend/src/main/java/project/backend/global/exception/errorcode/ChatRoomErrorCode.java
@@ -22,7 +22,8 @@ public enum ChatRoomErrorCode implements ErrorCode {
     TOO_MANY_REQUESTS("CRE-012", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
     SERVICE_UNAVAILABLE("CRE-013", "서비스가 일시적으로 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE),
     CHATROOM_FULL("CRE-014", "채팅방 인원이 가득 찼습니다.", HttpStatus.CONFLICT),
-    CHATROOM_LIMIT_EXCEEDED("CRE-015", "참여 가능한 채팅방 수를 초과했습니다.", HttpStatus.CONFLICT);
+    CHATROOM_LIMIT_EXCEEDED("CRE-015", "참여 가능한 채팅방 수를 초과했습니다.", HttpStatus.CONFLICT),
+    TRY_AGAIN("CRE-016", "잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
## 🛰️ Issue Number
close #41 

## 🪐 작업 내용

### ChatMessageIndexStatus INSERT 최적화
- `chatMessageIndexStatusRepository.save()` → `entityManager.persist()`로 변경
- id 직접 할당 방식에서 JPA save()는 SELECT 후 INSERT하는 문제 해결
- persist()로 영속성 컨텍스트에 직접 등록하여 불필요한 SELECT 제거

### 채팅방 참여 락 스코프 변경
- COUNT 쿼리의 PESSIMISTIC_WRITE 제거 (집계 쿼리에는 row 락 불가)
- `findByInviteCodeWithLock()`으로 ChatRoom row 자체에 락을 걸어 직렬화
- LockTimeoutException 핸들링 추가 → CRE-016 TRY_AGAIN 응답

## 기대 효과
- 채팅 메시지 저장 시 쿼리 수 감소 (SELECT + INSERT → INSERT)
- 동시 참여 요청에서 정원 초과 방지

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?