### PR TITLE
fix: DB 커넥션 풀 경합 방지를 위해 FallbackLimiter 세마포어 한도 7 → 4로 조정

### DIFF
--- a/backend/src/main/java/project/backend/global/ratelimit/FallbackLimiter.java
+++ b/backend/src/main/java/project/backend/global/ratelimit/FallbackLimiter.java
@@ -7,7 +7,7 @@ import java.util.concurrent.Semaphore;
 @Component
 public class FallbackLimiter {
 
-    private static final int MAX_CONCURRENT_FALLBACK = 7; // DB 커넥션 풀의 70%
+    private static final int MAX_CONCURRENT_FALLBACK = 4; //
     private final Semaphore semaphore = new Semaphore(MAX_CONCURRENT_FALLBACK);
 
     public boolean tryAcquire() {

--- a/backend/src/main/java/project/backend/global/ratelimit/FallbackLimiter.java
+++ b/backend/src/main/java/project/backend/global/ratelimit/FallbackLimiter.java
@@ -7,7 +7,7 @@ import java.util.concurrent.Semaphore;
 @Component
 public class FallbackLimiter {
 
-    private static final int MAX_CONCURRENT_FALLBACK = 4; //
+    private static final int MAX_CONCURRENT_FALLBACK = 4;
     private final Semaphore semaphore = new Semaphore(MAX_CONCURRENT_FALLBACK);
 
     public boolean tryAcquire() {


### PR DESCRIPTION
## 🛰️ Issue Number
close #43 

## 🪐 작업 내용
### 변경 사항
- fallback semaphore limit을 7 → 4로 조정

### 변경 이유
기존에는 DB 커넥션 풀(max 10)의 약 70%를 fallback에 할당하여 7로 설정했으나,
이 경우 fallback 요청과 일반 API 요청이 동시에 증가할 때
총 동시 요청 수가 커넥션 풀을 초과할 수 있는 문제가 있었습니다.

예:
- fallback 7 + 일반 API 4 = 11 → DB 커넥션 초과 → 대기 및 latency 증가

또한 fallback은 Redis 장애 시 DB로 우회되는 경로로,
정상 경로 대비 비용이 높은 작업이기 때문에 더 보수적인 제한이 필요하다고 판단했습니다.

### 개선 내용
- fallback 동시성을 DB 커넥션의 약 30~40% 수준으로 제한 (7 → 4)
- DB를 사용하는 fallback 경로만 별도로 보호하도록 조정

### 기대 효과
- Redis 장애 시 DB로의 트래픽 쏠림 방지
- 커넥션 풀 초과로 인한 대기 및 장애 전파 감소
- 일반 API 요청이 fallback에 의해 영향을 받는 상황 완화

### 비고
- 현재는 단일 인스턴스 기준 설정이며, 추후 서버 확장 시 커넥션 풀 크기 및 limiter 수치 재조정 필요

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?